### PR TITLE
페이지의 기본 URL을 배포, 개발 환경에 따라 유연하게 적용합니다

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "webpack-dev-server --progress",
-    "build": "webpack --progress"
+    "build": "webpack --mode=production --progress"
   },
   "repository": {
     "type": "git",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -5,7 +5,7 @@ import SignInPage from '../pages/SignInPage';
 
 export default function App() {
   return (
-    <div>
+    <>
       <Switch>
         <Route exact path="/">
           <SignInPage />
@@ -17,6 +17,6 @@ export default function App() {
           <div>회원가입</div>
         </Route>
       </Switch>
-    </div>
+    </>
   );
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,11 +6,11 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './components/App';
 import store from './store';
 
-console.log('process.env.PUBLIC_URL ? ', process.env.NODE_ENV);
+const isProduction = process.env.NODE_ENV === 'production';
 
 ReactDom.render(
   <Provider store={store}>
-    <BrowserRouter basename={process.env.PUBLIC_URL}>
+    <BrowserRouter basename={isProduction ? '/project-react-3-yoonhe' : '/'}>
       <App />
     </BrowserRouter>
   </Provider>,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,7 +10,7 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 ReactDom.render(
   <Provider store={store}>
-    <BrowserRouter basename={isProduction ? 'https://yoonhe.github.io/project-react-3-yoonhe/' : '/'}>
+    <BrowserRouter basename={isProduction ? '/project-react-3-yoonhe/' : '/'}>
       <App />
     </BrowserRouter>
   </Provider>,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,7 +6,7 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './components/App';
 import store from './store';
 
-console.log('process.env.PUBLIC_URL ? ', process.env.PUBLIC_URL);
+console.log('process.env.PUBLIC_URL ? ', process.env.NODE_ENV);
 
 ReactDom.render(
   <Provider store={store}>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,9 +6,11 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './components/App';
 import store from './store';
 
+console.log('process.env.PUBLIC_URL ? ', process.env.PUBLIC_URL);
+
 ReactDom.render(
   <Provider store={store}>
-    <BrowserRouter>
+    <BrowserRouter basename={process.env.PUBLIC_URL}>
       <App />
     </BrowserRouter>
   </Provider>,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,7 +10,7 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 ReactDom.render(
   <Provider store={store}>
-    <BrowserRouter basename={isProduction ? '/project-react-3-yoonhe' : '/'}>
+    <BrowserRouter basename={isProduction ? 'https://yoonhe.github.io/project-react-3-yoonhe/' : '/'}>
       <App />
     </BrowserRouter>
   </Provider>,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,7 +10,7 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 ReactDom.render(
   <Provider store={store}>
-    <BrowserRouter basename={isProduction ? '/project-react-3-yoonhe/' : '/'}>
+    <BrowserRouter basename={isProduction ? 'https://yoonhe.github.io/project-react-3-yoonhe/' : '/'}>
       <App />
     </BrowserRouter>
   </Provider>,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,7 +10,7 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 ReactDom.render(
   <Provider store={store}>
-    <BrowserRouter basename={isProduction ? 'https://yoonhe.github.io/project-react-3-yoonhe/' : '/'}>
+    <BrowserRouter basename={isProduction ? 'https://codesoom.github.io/project-react-3-yoonhe/' : '/'}>
       <App />
     </BrowserRouter>
   </Provider>,


### PR DESCRIPTION
개발 환경에서는 `Router`를 사용하는 부분이 잘 실행되지만 배포서버에서는 실행되지 않아 아래의 블로그를 참고하여 basename을 각 환경에따라 유연하게 적용될 수 있도록 변경해주었습니다.

## 궁금한점 👀
배포 서버의 루트 url은 `https://codesoom.github.io/` 인데 실제로 이 프로젝트가 담겨있는 경로는 `https://codesoom.github.io/project-react-3-yoonhe/`이기때문에 router가 경로를 찾지 못해 나는 에러라고 판단했습니다. 

그래서 첫번째 시도한 방법은 아래와같습니다. 
```js
<BrowserRouter basename={isProduction ? '/project-react-3-yoonhe/' : '/'}>
      <App />
    </BrowserRouter>
```
하지만 여전히 문제가 해결되지않아 두번째 방법으로 배포서버 URL 자체를 넣어보니 문제가 해결되었습니다 

```js
<BrowserRouter basename={isProduction ? 'https://codesoom.github.io/project-react-3-yoonhe/' : '/'}>
      <App />
    </BrowserRouter>
```

react-router-dom 공식문서에는 basename 사용법이 아래와같이 설명되어있는데요

```js
<BrowserRouter basename="/calendar">
    <Link to="/today"/> // renders <a href="/calendar/today">
    <Link to="/tomorrow"/> // renders <a href="/calendar/tomorrow">
    ...
</BrowserRouter>
``` 

여기서 궁금한점이 있습니다.
공식문서대로라면 배포서버에서 루트 경로가 `https://codesoom.github.io/` 라면 아래와같이 구현해줬을때`https://codesoom.github.io/project-react-3-yoonhe/`으로 기본 경로가 바뀌어 router가 기본 url 경로를 따라가야하는데
`basename={isProduction ? '/project-react-3-yoonhe/' : '/'`

왜 `basename={isProduction ? 'https://codesoom.github.io/project-react-3-yoonhe/' : '/'` 이렇게 전체 url을 넣어야만 router가 경로를 잘 찾아가는것일까요?...


참고글 : https://medium.com/@_diana_lee/react-react-router-%EC%A0%81%EC%9A%A9%ED%95%9C-react-%EC%95%B1%EC%9D%84-github-pages%EB%A1%9C-%EB%B0%B0%ED%8F%AC%ED%95%98%EB%8A%94-%EB%B2%95-5f6119c6a5d9