### PR TITLE
jest 설정 파일을 수정합니다

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,9 @@
 module.exports = {
   setupFilesAfterEnv: [
-    'given2/setup',
     'jest-plugin-context/setup',
     './jest.setup',
+  ],
+  setupFiles: [
+    'given2/setup',
   ],
 };


### PR DESCRIPTION
given을 글로벌 변수로 사용하기위해 jest 설정 파일을 수정합니다

## 문제 발생
`given`을 글로벌 변수로 사용하기위해 아래와같이 설정해줬지만 테스트 파일안에서
```js
// jest.config.js
module.exports = {
  setupFilesAfterEnv: [
    'jest-plugin-context/setup',
    './jest.setup',
    'given2/setup',
  ],
};
```
 given을 글로벌 변수로 인식하지못하는 문제가 발생하였습니다
![image](https://user-images.githubusercontent.com/53102889/113085446-c4977f80-921a-11eb-943d-b6eb91c3fcd1.png)

## 해결 방법
`given2/setup`을 setupFiles로 이동시켜 해결하였습니다
```js
module.exports = {
  setupFilesAfterEnv: [
    'jest-plugin-context/setup',
    './jest.setup',
  ],
  setupFiles: [
    'given2/setup',
  ],
};

```
