### PR TITLE
useSelector의 selector 콜백 함수를 utils로 이동시킵니다

### DIFF
--- a/src/container/SignInContainer.jsx
+++ b/src/container/SignInContainer.jsx
@@ -2,20 +2,21 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import SignIn from '../components/SignIn';
+
 import {
   authenticationChange,
   changeLoginFields,
   loginRequest,
 } from '../slice';
 
+import { get } from '../utils';
+
 export default function SignInContainer({ onGoToMainClick }) {
   const dispatch = useDispatch();
 
-  const isLoggedIn = useSelector((store) => store.isLoggedIn);
-  const loginFields = useSelector((store) => store.loginFields);
-  const loginError = useSelector((store) => store.loginError);
-
-  console.log('loginError ? ', loginError);
+  const isLoggedIn = useSelector(get('isLoggedIn'));
+  const loginFields = useSelector(get('loginFields'));
+  const loginError = useSelector(get('loginError'));
 
   useEffect(() => {
     dispatch(authenticationChange());

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,3 @@
+export function get(key) {
+  return (obj) => obj[key];
+}


### PR DESCRIPTION
중복되는 코드를 줄이기 위해 `useSelector`의 `selector 콜백 함수`를 `utils`로 이동시키고
사용하는곳에서 `import` 해서 사용하도록 코드를 수정합니다