### PR TITLE
dotenv 테스트를 위해 console.log를 추가합니다

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
           MESSAGING_SENDER_ID : ${{ secrets.MESSAGING_SENDER_ID }}
           APP_ID : ${{ secrets.APP_ID }}
           MEASUREMENT_ID : ${{ secrets.MEASUREMENT_ID }}
+          TEST : ${{ secrets.TEST }}
  
 
       - name: Install and Build 🔧 

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -13,6 +13,8 @@ const firebaseConfig = {
   measurementId: process.env.MEASUREMENT_ID,
 };
 
+console.log('process.env.API_KEY ? ', process.env.TEST);
+
 export const firebaseInstance = firebase.initializeApp(firebaseConfig);
 export const dbService = firebase.firestore();
 export const authService = firebase.auth();


### PR DESCRIPTION
배포서버에서 .evn 파일 값들이 잘 들어오는지 확인하기 위해 console.log를 사용합니다