### PR TITLE
오타를 수정합니다(MianPage => MainPage)

### DIFF
--- a/src/pages/MianPage.test.jsx
+++ b/src/pages/MianPage.test.jsx
@@ -2,12 +2,12 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
-import MianPage from './MainPage';
+import MainPage from './MainPage';
 
 jest.mock('../service/api');
 jest.mock('react-redux');
 
-describe('MianPage', () => {
+describe('MainPage', () => {
   const dispatch = jest.fn();
 
   beforeEach(() => {
@@ -16,9 +16,9 @@ describe('MianPage', () => {
     useDispatch.mockImplementation(() => dispatch);
   });
 
-  it('renders MianPage', () => {
+  it('renders MainPage', () => {
     const { queryByText } = render((
-      <MianPage />
+      <MainPage />
     ));
 
     expect(queryByText('메인 페이지')).not.toBeNull();


### PR DESCRIPTION
MainPage 테스트 코드에 `MianPage`로 잘못된 컴포넌트명이 들어가있어서 수정합니다