### PR TITLE
빌드 단계에서 `dist/index.html` 파일을 복사해 `404.html`을 만들어줍니다

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           npm install
           npm run build
+          cp dist/index.html dist/404.html
         env:
           API_KEY : ${{ secrets.API_KEY }}
           AUTH_DOMAIN : ${{ secrets.AUTH_DOMAIN }}


### PR DESCRIPTION
github pages에서 라우팅을 지원하지 않아 루트 경로 이외의 경로는
`404.html`을 반환합니다. 이를 해결하기 위해 빌드 단계에서
 `index.html`과 내용이 같은 `404.html`을 만들어서 `404.html`이
반환되었을때 `index.html` 내용이 보이도록 합니다