### PR TITLE
모바일 화면일때 방과 방 사이의 간격을 띄워주고, 스크린 좌우 여백을 줄입니다

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -100,6 +100,7 @@ const CenterSection = styled.section({
   marginLeft: '250px',
   [mediaQuery[768]]: {
     marginLeft: 'auto',
+    padding: '4rem 1.1rem',
   },
 });
 

--- a/src/components/RoomList.jsx
+++ b/src/components/RoomList.jsx
@@ -13,6 +13,9 @@ const List = styled.ul({
   justifyContent: 'space-between',
   gap: '2rem 0',
   marginTop: '1rem',
+  [mediaQuery[500]]: {
+    gap: '0',
+  },
 });
 
 const ListItem = styled.li({
@@ -36,6 +39,9 @@ const ListItem = styled.li({
   },
   [mediaQuery[500]]: {
     padding: '16.5rem 1.5rem 1.5rem 1.5rem',
+    '&+&': {
+      marginTop: '1.5rem',
+    },
   },
 });
 


### PR DESCRIPTION
좌우 여백을 줄여 방 리스트를 더 넓게 보여줍니다