### PR TITLE
오타를 수정합니다. (signIn => signUp)

### DIFF
--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -7,7 +7,7 @@ import {
   loadRooms,
   initialAddRoomFields,
   requestAddRoom,
-  signInRequest,
+  signUpRequest,
 } from './slice';
 
 import {
@@ -78,7 +78,7 @@ describe('actions', () => {
     });
   });
 
-  describe('signInRequest', () => {
+  describe('signUpRequest', () => {
     beforeEach(() => {
       jest.clearAllMocks();
 
@@ -90,45 +90,45 @@ describe('actions', () => {
       });
     });
 
-    context('when signin success', () => {
+    context('when signUp success', () => {
       beforeEach(() => {
         postSignup.mockResolvedValue();
       });
 
-      it('runs setIsLoggedIn', async () => {
-        await store.dispatch(signInRequest());
+      it('runs setSignUpRequest and setSignUpSuccess', async () => {
+        await store.dispatch(signUpRequest());
 
         const actions = store.getActions();
 
         expect(actions).toEqual([
           {
-            type: 'roomPreviews/setSignInRequest',
+            type: 'roomPreviews/setSignUpRequest',
           },
           {
-            type: 'roomPreviews/setSignInSuccess',
+            type: 'roomPreviews/setSignUpSuccess',
           },
         ]);
       });
     });
 
-    context('when signin failure', () => {
+    context('when signUp failure', () => {
       beforeEach(() => {
         postSignup.mockRejectedValue({
           code: 'auth/email-already-in-use',
         });
       });
 
-      it('runs setIsLoggedIn with false', async () => {
-        await store.dispatch(signInRequest());
+      it('runs setSignUpRequest and setSignUpFailure', async () => {
+        await store.dispatch(signUpRequest());
 
         const actions = store.getActions();
 
         expect(actions).toEqual([
           {
-            type: 'roomPreviews/setSignInRequest',
+            type: 'roomPreviews/setSignUpRequest',
           },
           {
-            type: 'roomPreviews/setSignInFailure',
+            type: 'roomPreviews/setSignUpFailure',
             payload: '이미 사용중인 메일입니다 👀',
           },
         ]);

--- a/src/components/App.test.jsx
+++ b/src/components/App.test.jsx
@@ -32,7 +32,7 @@ describe('App', () => {
         password: PASSWORD,
       },
       isLoggedIn: given.isLoggedIn || false,
-      signIn: {
+      signUp: {
         loading: false,
         success: false,
         failure: false,

--- a/src/container/SignUpContainer.test.jsx
+++ b/src/container/SignUpContainer.test.jsx
@@ -24,7 +24,7 @@ describe('SignUpContainer', () => {
         email: EMAIL,
         password: PASSWORD,
       },
-      signIn: {
+      signUp: {
         loading: false,
         success: false,
         failure: given.signinFailure || false,

--- a/src/pages/SignUpPage.test.jsx
+++ b/src/pages/SignUpPage.test.jsx
@@ -21,7 +21,7 @@ describe('SignUpPage', () => {
         email: EMAIL,
         password: PASSWORD,
       },
-      signIn: {
+      signUp: {
         loading: false,
         success: false,
         failure: false,

--- a/src/slice.js
+++ b/src/slice.js
@@ -35,7 +35,7 @@ const initialState = {
     email: '',
     password: '',
   },
-  signIn: {
+  signUp: {
     loading: false,
     success: false,
     failure: false,
@@ -89,36 +89,30 @@ const reducers = {
       loginError,
     };
   },
-  setSignInRequest(state) {
+  setSignUpRequest(state) {
     return {
       ...state,
-      signIn: {
+      signUp: {
         loading: true,
         success: false,
         failure: false,
       },
     };
   },
-  setSignInSuccess(state) {
-    const { signIn } = state;
-
+  setSignUpSuccess(state) {
     return {
       ...state,
-      signIn: {
-        ...signIn,
+      signUp: {
         loading: false,
         success: true,
         failure: false,
       },
     };
   },
-  setSignInFailure(state, { payload: errorMessage }) {
-    const { signIn } = state;
-
+  setSignUpFailure(state, { payload: errorMessage }) {
     return {
       ...state,
-      signIn: {
-        ...signIn,
+      signUp: {
         loading: false,
         success: false,
         failure: errorMessage,
@@ -174,9 +168,9 @@ export const {
   changeRoomImages,
   addRoom,
   changeSignInFields,
-  setSignInRequest,
-  setSignInSuccess,
-  setSignInFailure,
+  setSignUpRequest,
+  setSignUpSuccess,
+  setSignUpFailure,
 } = actions;
 
 export function loginRequest() {
@@ -201,14 +195,14 @@ export function loginRequest() {
   };
 }
 
-export function signInRequest() {
+export function signUpRequest() {
   return async (dispatch, getState) => {
     const { signInFields } = getState();
     const { email, password } = signInFields;
-    dispatch(setSignInRequest());
+    dispatch(setSignUpRequest());
     try {
       await postSignup({ email, password });
-      dispatch(setSignInSuccess());
+      dispatch(setSignUpSuccess());
     } catch (error) {
       const errors = {
         'auth/invalid-email': '이메일을 입력해주세요 👀',
@@ -218,7 +212,7 @@ export function signInRequest() {
 
       const { code } = error;
 
-      dispatch(setSignInFailure(errors[code]));
+      dispatch(setSignUpFailure(errors[code]));
     }
   };
 }

--- a/src/slice.test.js
+++ b/src/slice.test.js
@@ -9,9 +9,9 @@ import reducer, {
   changeRoomImages,
   initialAddRoomFields,
   changeSignInFields,
-  setSignInRequest,
-  setSignInSuccess,
-  setSignInFailure,
+  setSignUpRequest,
+  setSignUpSuccess,
+  setSignUpFailure,
 } from './slice';
 
 import { email as EMAIL } from '../fixtures/loginFields';
@@ -33,7 +33,7 @@ describe('reducer', () => {
         email: '',
         password: '',
       },
-      signIn: {
+      signUp: {
         loading: false,
         success: false,
         failure: false,
@@ -197,54 +197,54 @@ describe('reducer', () => {
   describe('siginInRequest', () => {
     it('change signIn loading', () => {
       const initialState = {
-        signIn: {
+        signUp: {
           loading: false,
           success: false,
           failure: false,
         },
       };
 
-      const state = reducer(initialState, setSignInRequest());
+      const state = reducer(initialState, setSignUpRequest());
 
-      expect(state.signIn.loading).toBe(true);
-      expect(state.signIn.success).toBe(false);
-      expect(state.signIn.failure).toBe(false);
+      expect(state.signUp.loading).toBe(true);
+      expect(state.signUp.success).toBe(false);
+      expect(state.signUp.failure).toBe(false);
     });
   });
 
-  describe('setSignInSuccess', () => {
+  describe('setSignUpSuccess', () => {
     it('change signIn loading and success', () => {
       const initialState = {
-        signIn: {
+        signUp: {
           loading: true,
           success: false,
           failure: 'ERROR_MESSAGE',
         },
       };
 
-      const state = reducer(initialState, setSignInSuccess());
+      const state = reducer(initialState, setSignUpSuccess());
 
-      expect(state.signIn.loading).toBe(false);
-      expect(state.signIn.success).toBe(true);
-      expect(state.signIn.failure).toBe(false);
+      expect(state.signUp.loading).toBe(false);
+      expect(state.signUp.success).toBe(true);
+      expect(state.signUp.failure).toBe(false);
     });
   });
 
-  describe('setSignInFailure', () => {
+  describe('setSignUpFailure', () => {
     it('change signIn loading and failure', () => {
       const initialState = {
-        signIn: {
+        signUp: {
           loading: true,
           success: false,
           failure: false,
         },
       };
 
-      const state = reducer(initialState, setSignInFailure('ERROR_MESSAGE'));
+      const state = reducer(initialState, setSignUpFailure('ERROR_MESSAGE'));
 
-      expect(state.signIn.loading).toBe(false);
-      expect(state.signIn.success).toBe(false);
-      expect(state.signIn.failure).toBe('ERROR_MESSAGE');
+      expect(state.signUp.loading).toBe(false);
+      expect(state.signUp.success).toBe(false);
+      expect(state.signUp.failure).toBe('ERROR_MESSAGE');
     });
   });
 });


### PR DESCRIPTION
회원가입에 관련된 `state`와 `테스트 시나리오` 등등에 사용된
`sign in`이라는 표현을 `sign up`으로 변경합니다